### PR TITLE
Add admin panel basics with suggestions

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,22 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Game;
+use App\Models\Genre;
+use App\Models\Platform;
+use App\Models\GameSuggestion;
+use App\Models\PlatformSuggestion;
+
+class AdminController extends Controller
+{
+    public function index()
+    {
+        $games = Game::all();
+        $genres = Genre::all();
+        $platforms = Platform::all();
+        $gameSuggestions = GameSuggestion::where('approved', false)->get();
+        $platformSuggestions = PlatformSuggestion::where('approved', false)->get();
+        return view('admin.panel', compact('games', 'genres', 'platforms', 'gameSuggestions', 'platformSuggestions'));
+    }
+}

--- a/app/Http/Controllers/GameSuggestionController.php
+++ b/app/Http/Controllers/GameSuggestionController.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\GameSuggestion;
+
+class GameSuggestionController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string',
+            'description' => 'nullable|string',
+            'link' => 'nullable|string',
+        ]);
+        $validated['user_id'] = $request->user()?->id_user;
+        $suggestion = GameSuggestion::create($validated);
+        return response()->json($suggestion, 201);
+    }
+
+    public function approve(GameSuggestion $suggestion)
+    {
+        $suggestion->approved = true;
+        $suggestion->save();
+        return response()->json(['message' => 'Approved']);
+    }
+}

--- a/app/Http/Controllers/PlatformSuggestionController.php
+++ b/app/Http/Controllers/PlatformSuggestionController.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\PlatformSuggestion;
+
+class PlatformSuggestionController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'platform' => 'required|string',
+            'link' => 'nullable|string',
+            'id_game' => 'nullable|integer',
+        ]);
+        $validated['user_id'] = $request->user()?->id_user;
+        $suggestion = PlatformSuggestion::create($validated);
+        return response()->json($suggestion, 201);
+    }
+
+    public function approve(PlatformSuggestion $suggestion)
+    {
+        $suggestion->approved = true;
+        $suggestion->save();
+        return response()->json(['message' => 'Approved']);
+    }
+}

--- a/app/Http/Middleware/EnsureAdmin.php
+++ b/app/Http/Middleware/EnsureAdmin.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureAdmin
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $user = $request->user();
+        if (!$user || !$user->is_admin) {
+            abort(403, 'Unauthorized');
+        }
+        return $next($request);
+    }
+}

--- a/app/Models/GameSuggestion.php
+++ b/app/Models/GameSuggestion.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class GameSuggestion extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id', 'title', 'description', 'link', 'approved'
+    ];
+}

--- a/app/Models/PlatformSuggestion.php
+++ b/app/Models/PlatformSuggestion.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class PlatformSuggestion extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id', 'id_game', 'platform', 'link', 'approved'
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -27,6 +27,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'is_admin',
     ];
 
     /**
@@ -49,6 +50,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\EnsureAdmin::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->boolean('is_admin')->default(false);
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/migrations/2025_06_14_000004_create_game_suggestions_table.php
+++ b/database/migrations/2025_06_14_000004_create_game_suggestions_table.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('game_suggestions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('link')->nullable();
+            $table->boolean('approved')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('game_suggestions');
+    }
+};

--- a/database/migrations/2025_06_14_000005_create_platform_suggestions_table.php
+++ b/database/migrations/2025_06_14_000005_create_platform_suggestions_table.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('platform_suggestions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->unsignedBigInteger('id_game')->nullable();
+            $table->string('platform');
+            $table->string('link')->nullable();
+            $table->boolean('approved')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('platform_suggestions');
+    }
+};

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1,0 +1,6 @@
+(function(){
+    const isAdmin = localStorage.getItem('is_admin');
+    if(isAdmin !== '1' && isAdmin !== 'true') {
+        window.location.href = '/home';
+    }
+})();

--- a/public/js/home.js
+++ b/public/js/home.js
@@ -1,6 +1,7 @@
 function logout() {
     localStorage.removeItem('token');
     localStorage.removeItem('name');
+    localStorage.removeItem('is_admin');
     window.location.reload();
 }
 
@@ -9,6 +10,7 @@ function renderNavbar() {
     navbarRight.innerHTML = '';
     const token = localStorage.getItem('token');
     const name = localStorage.getItem('name') || 'Utilisateur';
+    const isAdmin = localStorage.getItem('is_admin');
     if (!token) {
         navbarRight.innerHTML = `
             <li class="nav-item">
@@ -25,6 +27,7 @@ function renderNavbar() {
                     <i class="bi bi-person-circle"></i> ${name}
                 </a>
                 <ul class="dropdown-menu dropdown-menu-end">
+                    ${isAdmin === '1' || isAdmin === 'true' ? '<li><a class="dropdown-item" href="/admin">Administration</a></li><li><hr class="dropdown-divider"></li>' : ''}
                     <li><a class="dropdown-item" href="#">Ma wishlist</a></li>
                     <li><a class="dropdown-item" href="#">Mes jeux</a></li>
                     <li><hr class="dropdown-divider"></li>

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -16,6 +16,9 @@ document.getElementById('loginForm').addEventListener('submit', async function(e
             if (data.user && data.user.name) {
                 localStorage.setItem('name', data.user.name);
             }
+            if (data.user && data.user.is_admin !== undefined) {
+                localStorage.setItem('is_admin', data.user.is_admin ? '1' : '0');
+            }
             messageDiv.innerHTML = '<div class="alert alert-success">Connexion réussie !</div>';
             window.location.href = 'home';
         } else {

--- a/public/js/register.js
+++ b/public/js/register.js
@@ -35,6 +35,9 @@ document.getElementById('registerForm').addEventListener('submit', async functio
             if (data.user && data.user.name) {
                 localStorage.setItem('name', data.user.name);
             }
+            if (data.user && data.user.is_admin !== undefined) {
+                localStorage.setItem('is_admin', data.user.is_admin ? '1' : '0');
+            }
             messageDiv.innerHTML = '<div class="alert alert-success">Inscription réussie !</div>';
             window.location.href = 'home';
         } else {

--- a/public/js/suggest_game.js
+++ b/public/js/suggest_game.js
@@ -1,0 +1,23 @@
+document.getElementById('suggestGameForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const title = document.getElementById('title').value;
+    const description = document.getElementById('description').value;
+    const link = document.getElementById('link').value;
+    const token = localStorage.getItem('token');
+    const res = await fetch('/api/suggestions/games', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            ...(token ? { 'Authorization': 'Bearer ' + token } : {})
+        },
+        body: JSON.stringify({ title, description, link })
+    });
+    const data = await res.json();
+    const msg = document.getElementById('message');
+    if(res.ok) {
+        msg.innerHTML = '<div class="alert alert-success">Suggestion envoyée</div>';
+    } else {
+        msg.innerHTML = '<div class="alert alert-danger">Erreur</div>';
+    }
+});

--- a/resources/views/admin/panel.blade.php
+++ b/resources/views/admin/panel.blade.php
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="fr" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <title>Panel Admin</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-dark text-light">
+<div class="container mt-5">
+    <h1 class="mb-4">Administration</h1>
+    <p>Gestion des jeux, plateformes et catégories.</p>
+
+    <h2 class="mt-5">Suggestions de jeux</h2>
+    <ul class="list-group mb-4">
+        @forelse($gameSuggestions as $suggestion)
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+                <span>{{ $suggestion->title }}</span>
+            </li>
+        @empty
+            <li class="list-group-item">Aucune suggestion.</li>
+        @endforelse
+    </ul>
+
+    <h2>Suggestions de plateformes</h2>
+    <ul class="list-group">
+        @forelse($platformSuggestions as $suggestion)
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+                <span>{{ $suggestion->platform }} - {{ $suggestion->link }}</span>
+            </li>
+        @empty
+            <li class="list-group-item">Aucune suggestion.</li>
+        @endforelse
+    </ul>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ asset('js/admin.js') }}"></script>
+</body>
+</html>

--- a/resources/views/suggest_game.blade.php
+++ b/resources/views/suggest_game.blade.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="fr" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <title>Proposer un jeu</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-dark text-light">
+<div class="container mt-5">
+    <h1 class="mb-4">Proposer un jeu</h1>
+    <form id="suggestGameForm">
+        <div class="mb-3">
+            <label class="form-label">Titre</label>
+            <input type="text" class="form-control" id="title" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Description</label>
+            <textarea class="form-control" id="description"></textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Lien</label>
+            <input type="text" class="form-control" id="link">
+        </div>
+        <button type="submit" class="btn btn-primary">Envoyer</button>
+    </form>
+    <div id="message" class="mt-3"></div>
+</div>
+<script src="{{ asset('js/suggest_game.js') }}"></script>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\GameController;
+use App\Http\Controllers\GameSuggestionController;
+use App\Http\Controllers\PlatformSuggestionController;
 
 /*
 |--------------------------------------------------------------------------
@@ -27,3 +29,11 @@ Route::middleware('auth:sanctum')->group(function () {
 Route::get('/games', [GameController::class, 'index']);
 Route::post('/games', [GameController::class, 'store']);
 Route::get('/games/{id_game}', [GameController::class, 'show']);
+
+Route::post('/suggestions/games', [GameSuggestionController::class, 'store']);
+Route::post('/suggestions/platforms', [PlatformSuggestionController::class, 'store']);
+
+Route::middleware(['auth:sanctum', 'admin'])->group(function () {
+    Route::post('/suggestions/games/{suggestion}/approve', [GameSuggestionController::class, 'approve']);
+    Route::post('/suggestions/platforms/{suggestion}/approve', [PlatformSuggestionController::class, 'approve']);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,10 +2,14 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\AdminController;
 
 Route::get('/home', [HomeController::class, 'index'])->name('home');
 Route::view('/login', 'login')->name('login');
 Route::view('/register', 'register')->name('register');
+Route::view('/suggest-game', 'suggest_game')->name('suggest.game');
+
+Route::get('/admin', [AdminController::class, 'index'])->name('admin.panel');
 
 // Fallback : toute autre route renvoie vers la home
 Route::fallback(function () {

--- a/tests/Unit/UsersTableTest.php
+++ b/tests/Unit/UsersTableTest.php
@@ -15,7 +15,7 @@ class UsersTableTest extends TestCase
     {
         $this->assertTrue(Schema::hasTable('users'));
         $this->assertTrue(Schema::hasColumns('users', [
-            'id_user', 'name', 'email', 'password', 'created_at', 'updated_at'
+            'id_user', 'name', 'email', 'password', 'is_admin', 'created_at', 'updated_at'
         ]));
     }
 
@@ -25,6 +25,7 @@ class UsersTableTest extends TestCase
             'name' => 'testuser',
             'email' => 'test@example.com',
             'password' => bcrypt('secret'),
+            'is_admin' => true,
             'created_at' => now(),
             'updated_at' => now(),
         ]);


### PR DESCRIPTION
## Summary
- add `is_admin` field to users and update model
- create middleware and admin panel route
- implement basic admin controller and views
- allow suggestions of games and platforms via API
- store admin flag in browser storage on login or register
- expand tests for new user column
